### PR TITLE
Extended to version 0.2

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,2 @@
+Jakob Voss <voss@gbv.de> <jakob@nichtich.de>
+Yo-An Lin (林佑安) <cornelius@cpan.org> <cornelius.howl@gmail.com>

--- a/Changes
+++ b/Changes
@@ -1,11 +1,12 @@
 Revision history for Perl extension Git::Hook::PostReceive
 
-0.2    Mon Aug 12 16:03:06 2013 +0200
+0.2    Tue Aug 13 10:31:02 2013 +0200
         - removed non-core dependencies
         - changed payload format to align with GitHub
         - extended documentation
         - added unit tests
         - added utf8 decoding option
+        - extended method read_stdin
 
 0.01    Thu Jun 28 15:49:42 2012
         - original version

--- a/Changes
+++ b/Changes
@@ -1,10 +1,11 @@
 Revision history for Perl extension Git::Hook::PostReceive
 
-0.2    Sun Aug 11 20:37:33 2013
+0.2    Mon Aug 12 16:03:06 2013 +0200
         - removed non-core dependencies
         - changed payload format to align with GitHub
         - extended documentation
         - added unit tests
+        - added utf8 decoding option
 
 0.01    Thu Jun 28 15:49:42 2012
         - original version

--- a/dist.ini
+++ b/dist.ini
@@ -8,7 +8,6 @@ copyright_holder = Yo-An Lin
 [@Basic]
 [PkgVersion]
 [PodWeaver]
-; authordep Pod::Weaver::Plugin::ContributorsFromGit
 [ContributorsFromGit]
 [Test::Perl::Critic]
 [Test::PodSpelling]

--- a/dist.ini
+++ b/dist.ini
@@ -8,12 +8,14 @@ copyright_holder = Yo-An Lin
 [@Basic]
 [PkgVersion]
 [PodWeaver]
+; authordep Pod::Weaver::Plugin::ContributorsFromGit
+[ContributorsFromGit]
 [Test::Perl::Critic]
 [Test::PodSpelling]
 [PerlTidy]
 
 [Prereqs]
-perl  = 5.010 ; includes File::Basename and Cwd
+perl  = 5.010
 
 [PruneFiles]
 filename = dist.ini

--- a/dist.ini
+++ b/dist.ini
@@ -1,6 +1,6 @@
 name             = Git-Hook-PostReceive
 license          = Perl_5
-version          = 0.1
+version          = 0.2
 copyright_year   = 2013
 author           = Yo-An Lin
 copyright_holder = Yo-An Lin

--- a/lib/Git/Hook/PostReceive.pm
+++ b/lib/Git/Hook/PostReceive.pm
@@ -261,10 +261,8 @@ Jakob Voss <voss@gbv.de>
 
 =item *
 
-Yo-An Lin (林佑安) <cornelius@cpan.org>
+Yo-An Lin <cornelius@cpan.org>
 
 =back
 
 =cut
-
-=encoding utf8

--- a/lib/Git/Hook/PostReceive.pm
+++ b/lib/Git/Hook/PostReceive.pm
@@ -251,4 +251,20 @@ C<$ref>. Returns undef on failure.
 
 L<Git::Repository>, L<Plack::App::GitHub::WebHook>
 
+=head1 CONTRIBUTORS
+
+=over 4
+
+=item *
+
+Jakob Voss <voss@gbv.de>
+
+=item *
+
+Yo-An Lin (林佑安) <cornelius@cpan.org>
+
+=back
+
+=cut
+
 =encoding utf8

--- a/lib/Git/Hook/PostReceive.pm
+++ b/lib/Git/Hook/PostReceive.pm
@@ -251,3 +251,4 @@ C<$ref>. Returns undef on failure.
 
 L<Git::Repository>, L<Plack::App::GitHub::WebHook>
 
+=encoding utf8

--- a/lib/Git/Hook/PostReceive.pm
+++ b/lib/Git/Hook/PostReceive.pm
@@ -17,7 +17,7 @@ sub read_stdin {
 
     chomp $line;
     my @args = split /\s+/, $line;
-    return $self->run( @args );
+    return @args ? $self->run( @args ) : undef;
 }
 
 sub run {

--- a/weaver.ini
+++ b/weaver.ini
@@ -1,0 +1,2 @@
+[@Default]
+[Contributors]

--- a/weaver.ini
+++ b/weaver.ini
@@ -1,2 +1,0 @@
-[@Default]
-[Contributors]


### PR DESCRIPTION
I further extended some bits for version 0.2:
- argument to `read_stdin` is now optional
- decode utf8 on request - **should this be enable by default?!**
- increased test code coverage to 100%

With this changes one can create a post-recieve hook that emulates GitHub webhooks:

```
   use Git::Hook::PostReceive 0.2;
    use LWP::UserAgent;
    use JSON;

    my $ua = LWP::UserAgent->new;
    for (Git::Hook::PostReceive->new( utf8 => 1 )->read_stdin) {
        $ua->post( "http://example.org/webhook", { 'payload' => to_json($_) } );
    }
```

To release at CPAN when your applications have been tested:

```
dzil authordeps | cpanm
dzil release
```
